### PR TITLE
Pin to Pydantic 1.x

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @mattwthompson
+* @j-wags @mattwthompson

--- a/README.md
+++ b/README.md
@@ -146,5 +146,6 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
+* [@j-wags](https://github.com/j-wags/)
 * [@mattwthompson](https://github.com/mattwthompson/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ outputs:
       run:
         - python >=3.8
         - numpy
-        - pydantic
+        - pydantic <2.0.0a0
         - openmm >=7.6
         - openff-toolkit-base =>0.11.0rc2
         - openff-units >=0.1.6

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "openff-interchange" %}
-{% set version = "0.2.0rc1" %}
+{% set version = "0.2.0rc2" %}
 
 package:
   name: openff-interchange-split

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,7 +8,7 @@ package:
 source:
   path: ./build_base.sh
   url: https://github.com/openforcefield/openff-interchange/archive/refs/tags/v0.2.0-rc.2.tar.gz
-  sha256: 486fb02b569ae8021bc7a11ec0271e989fb4ba0bcf4dbfae70c2f296b6d88b4c
+  sha256: ed338c2a8861db96003ecec6faa33e0415f057a2e05a3dca6285d448e8156279
 
 build:
   number: 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 486fb02b569ae8021bc7a11ec0271e989fb4ba0bcf4dbfae70c2f296b6d88b4c
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - name: openff-interchange-base


### PR DESCRIPTION
Colvin has communicated a rough Q4 2022 timeframe for Pydantic 2.0. It would behoove us to start pinning earlier than later to avoid old builds being installed in incompatible ways.

Note that I'm not sure how broad the breaking changes will actually be. I'm just assuming a proper major version bump will break something.

https://pydantic-docs.helpmanual.io/blog/pydantic-v2

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
