### PR TITLE
Make an off-label build that allows Pydantic v2

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -15,11 +15,6 @@ jobs:
   timeoutInMinutes: 360
 
   steps:
-  - script: |
-         rm -rf /opt/ghc
-         df -h
-    displayName: Manage disk space
-
   # configure qemu binfmt-misc running.  This allows us to run docker containers
   # embedded qemu-static
   - script: |

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -3,6 +3,6 @@ cdt_name:
 channel_sources:
 - conda-forge/label/openff-models_rc,conda-forge
 channel_targets:
-- conda-forge/label/openff-interchange_rc
+- conda-forge openff-interchange_rc
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,8 +1,8 @@
 cdt_name:
 - cos6
 channel_sources:
-- conda-forge
+- conda-forge conda-forge/label/openff-models_rc
 channel_targets:
-- conda-forge main
+- conda-forge openff-interchange_rc
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,8 +1,8 @@
 cdt_name:
 - cos6
 channel_sources:
-- conda-forge conda-forge/label/openff-models_rc
+- conda-forge/label/openff-models_rc,conda-forge
 channel_targets:
-- conda-forge openff-interchange_rc
+- conda-forge/label/openff-interchange_rc
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,4 +1,4 @@
 channel_sources:
-  - conda-forge conda-forge/label/openff-models_rc
+  - conda-forge/label/openff-models_rc,conda-forge
 channel_targets:
-  - conda-forge openff-interchange_rc
+  - conda-forge/label/openff-interchange_rc

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,4 +1,4 @@
 channel_sources:
   - conda-forge/label/openff-models_rc,conda-forge
 channel_targets:
-  - conda-forge/label/openff-interchange_rc
+  - conda-forge openff-interchange_rc

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,4 @@
+channel_sources:
+  - conda-forge conda-forge/label/openff-models_rc
+channel_targets:
+  - conda-forge openff-interchange_rc

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "openff-interchange" %}
-{% set version = "0.3.8" %}
+{% set version = "0.3.9" %}
 
 package:
   name: openff-interchange-split
@@ -8,7 +8,7 @@ package:
 source:
   path: ./build_base.sh
   url: https://github.com/openforcefield/openff-interchange/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 1d564448b92cebf2ad9057f3174c3b7254606ca91f8e4c8757a4366682b8814e
+  sha256: 604863c602f7edc76f9bb99aa3ead40abcf5640a9e7b224adff0be9e4597804a
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 58b3d2ec05d5babe24761e58711ad01be7be57e5ae51b1721f7c494cc9c1056c
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - name: openff-interchange-base

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 604863c602f7edc76f9bb99aa3ead40abcf5640a9e7b224adff0be9e4597804a
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - name: openff-interchange-base
@@ -25,7 +25,7 @@ outputs:
         - pip
       run:
         - python >=3.9,<3.12.0a0
-        - pydantic >=1.10.8,<2.0.0a0
+        - pydantic =1.10.11
         - openmm >=7.6
         - openff-toolkit-base >=0.13
         - openff-units =0.2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "openff-interchange" %}
-{% set version = "0.3.7" %}
+{% set version = "0.3.8" %}
 
 package:
   name: openff-interchange-split
@@ -8,7 +8,7 @@ package:
 source:
   path: ./build_base.sh
   url: https://github.com/openforcefield/openff-interchange/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 0a3d87172f3387d919e19d2dbd4b0074f217be79fd712c883ba0ce655c812707
+  sha256: 1d564448b92cebf2ad9057f3174c3b7254606ca91f8e4c8757a4366682b8814e
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,7 +8,7 @@ package:
 source:
   path: ./build_base.sh
   url: https://github.com/openforcefield/openff-interchange/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 604863c602f7edc76f9bb99aa3ead40abcf5640a9e7b224adff0be9e4597804a
+  sha256: 58b3d2ec05d5babe24761e58711ad01be7be57e5ae51b1721f7c494cc9c1056c
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 604863c602f7edc76f9bb99aa3ead40abcf5640a9e7b224adff0be9e4597804a
 
 build:
-  number: 1
+  number: 0
 
 outputs:
   - name: openff-interchange-base
@@ -25,7 +25,7 @@ outputs:
         - pip
       run:
         - python >=3.9,<3.12.0a0
-        - pydantic =1.10.11
+        - pydantic >=1.10
         - openmm >=7.6
         - openff-toolkit-base >=0.13
         - openff-units =0.2


### PR DESCRIPTION
Currently I can't test Interchange with v2 because of the deployment constraints. 2 is bigger than 1

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
