### PR TITLE
Remove python 3.13 upper bound

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   git_depth: -1
 
 build:
-  number: 1
+  number: 2
 
 outputs:
   - name: openff-interchange-base
@@ -27,7 +27,7 @@ outputs:
         - setuptools
         - versioningit
       run:
-        - python >={{ python_min }},<3.13.0a0
+        - python >={{ python_min }}
         - pydantic =2
         - openff-toolkit-base ~=0.16.4
         - openff-units
@@ -54,7 +54,7 @@ outputs:
       host:
         - python {{ python_min }}
       run:
-        - python >={{ python_min }},<3.13.0a0
+        - python >={{ python_min }}
         - openmm =8
         - {{ pin_subpackage('openff-interchange-base', exact=True) }}
         - openff-toolkit ~=0.16.4

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,7 +42,7 @@ outputs:
 
     test:
       requires:
-        - python {{ python_min }}
+        - python 3.13
       imports:
         - openff.interchange
 
@@ -62,7 +62,7 @@ outputs:
 
     test:
       requires:
-        - python {{ python_min }}
+        - python 3.13
       imports:
         - openff.interchange
       files:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
This is targeting the `0.4.1_x` branch so we can rebuild `0.4.1` without the upper bound on python.