### PR TITLE
Add `openff-packmol` dependency

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 78247c40e2ae6af6ad1cf8775f854e326fdd7513c9e783eee690f5fd1ef2c599
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - name: openff-interchange-base
@@ -61,6 +61,7 @@ outputs:
         - openmm =8
         - {{ pin_subpackage('openff-interchange-base', exact=True) }}
         - openff-toolkit >=0.17.0,<0.19
+        - openff-packmol
         - pyedr
 
     test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -73,6 +73,7 @@ outputs:
         - test_stack_imports.py
       commands:
         - python test_stack_imports.py
+        - which packmol  # doesn't seem to be a packmol --version or similar help command
 
 about:
   home: https://openforcefield.org/


### PR DESCRIPTION
Fixes #127

AmberTools packaging causes us some pain both in general and in a handful of specific cases. This is one such case. This is better documented [elsewhere](https://github.com/conda-forge/openff-packmol-feedstock/issues/1) but AmberTools and Packmol (the conda package) cannot be installed against each other. Among an array of possible solutions, the current solution is for `openff-packmol` to just not install either. 
1. If AmberTools is installed, there is a `packmol` executable. This is what happens when a user does `conda install openff-toolkit` and it's important that behavior is safe and stable
2. If AmberTools is _not_ installed, that means the user opted into `openff-toolkit-base` and needs to install a `packmol` (the executable) provider one way or another. This can be the AmberTools or Packmol conda packages or something else that puts the executable on their machine. This is the non-standard/power-user path and I'm confident that audience can handle this.


<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
